### PR TITLE
2. Update to ESLint 10.

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,143 @@
+# ESLint Config Migration Notes
+
+### Rules removed from ESLint core (moved to `@stylistic/eslint-plugin`)
+
+The following rules were deprecated in **ESLint v8.53.0** and removed in **ESLint v10.0.0**. They are now provided by `@stylistic/eslint-plugin` with a `@stylistic/` prefix and identical options.
+
+| Old rule (ESLint core)            | New rule (`@stylistic/eslint-plugin`)        |
+| --------------------------------- | -------------------------------------------- |
+| `array-bracket-spacing`           | `@stylistic/array-bracket-spacing`           |
+| `arrow-parens`                    | `@stylistic/arrow-parens`                    |
+| `arrow-spacing`                   | `@stylistic/arrow-spacing`                   |
+| `block-spacing`                   | `@stylistic/block-spacing`                   |
+| `brace-style`                     | `@stylistic/brace-style`                     |
+| `comma-dangle`                    | `@stylistic/comma-dangle`                    |
+| `comma-spacing`                   | `@stylistic/comma-spacing`                   |
+| `comma-style`                     | `@stylistic/comma-style`                     |
+| `computed-property-spacing`       | `@stylistic/computed-property-spacing`       |
+| `dot-location`                    | `@stylistic/dot-location`                    |
+| `eol-last`                        | `@stylistic/eol-last`                        |
+| `func-call-spacing`               | `@stylistic/function-call-spacing` (renamed) |
+| `generator-star-spacing`          | `@stylistic/generator-star-spacing`          |
+| `indent`                          | `@stylistic/indent`                          |
+| `jsx-quotes`                      | `@stylistic/jsx-quotes`                      |
+| `key-spacing`                     | `@stylistic/key-spacing`                     |
+| `keyword-spacing`                 | `@stylistic/keyword-spacing`                 |
+| `linebreak-style`                 | `@stylistic/linebreak-style`                 |
+| `max-statements-per-line`         | `@stylistic/max-statements-per-line`         |
+| `new-parens`                      | `@stylistic/new-parens`                      |
+| `no-confusing-arrow`              | `@stylistic/no-confusing-arrow`              |
+| `no-extra-parens`                 | `@stylistic/no-extra-parens`                 |
+| `no-floating-decimal`             | `@stylistic/no-floating-decimal`             |
+| `no-mixed-operators`              | `@stylistic/no-mixed-operators`              |
+| `no-multi-spaces`                 | `@stylistic/no-multi-spaces`                 |
+| `no-multiple-empty-lines`         | `@stylistic/no-multiple-empty-lines`         |
+| `no-tabs`                         | `@stylistic/no-tabs`                         |
+| `no-trailing-spaces`              | `@stylistic/no-trailing-spaces`              |
+| `no-whitespace-before-property`   | `@stylistic/no-whitespace-before-property`   |
+| `object-curly-newline`            | `@stylistic/object-curly-newline`            |
+| `object-curly-spacing`            | `@stylistic/object-curly-spacing`            |
+| `object-property-newline`         | `@stylistic/object-property-newline`         |
+| `one-var-declaration-per-line`    | `@stylistic/one-var-declaration-per-line`    |
+| `operator-linebreak`              | `@stylistic/operator-linebreak`              |
+| `padded-blocks`                   | `@stylistic/padded-blocks`                   |
+| `padding-line-between-statements` | `@stylistic/padding-line-between-statements` |
+| `quote-props`                     | `@stylistic/quote-props`                     |
+| `quotes`                          | `@stylistic/quotes`                          |
+| `rest-spread-spacing`             | `@stylistic/rest-spread-spacing`             |
+| `semi`                            | `@stylistic/semi`                            |
+| `semi-spacing`                    | `@stylistic/semi-spacing`                    |
+| `space-before-blocks`             | `@stylistic/space-before-blocks`             |
+| `space-before-function-paren`     | `@stylistic/space-before-function-paren`     |
+| `space-in-parens`                 | `@stylistic/space-in-parens`                 |
+| `space-infix-ops`                 | `@stylistic/space-infix-ops`                 |
+| `space-unary-ops`                 | `@stylistic/space-unary-ops`                 |
+| `spaced-comment`                  | `@stylistic/spaced-comment`                  |
+| `template-curly-spacing`          | `@stylistic/template-curly-spacing`          |
+| `template-tag-spacing`            | `@stylistic/template-tag-spacing`            |
+| `wrap-iife`                       | `@stylistic/wrap-iife`                       |
+| `yield-star-spacing`              | `@stylistic/yield-star-spacing`              |
+
+> **Note:** `func-call-spacing` was renamed to `function-call-spacing` in `@stylistic/eslint-plugin`. The options are identical.
+
+### Rules removed from ESLint core (moved to `eslint-plugin-n`)
+
+The following rules present in the old config were removed from ESLint core into a dedicated, community supported ESLint node plugin. The new config enables these via `eslint-plugin-n` with the `n/` prefix. The legacy tests map these to their `n/` replacements.
+
+| Old rule (ESLint core)  | New rule (`eslint-plugin-n`) |
+| ----------------------- | ---------------------------- |
+| `callback-return`       | `n/callback-return`          |
+| `global-require`        | `n/global-require`           |
+| `handle-callback-err`   | `n/handle-callback-err`      |
+| `no-mixed-requires`     | `n/no-mixed-requires`        |
+| `no-new-require`        | `n/no-new-require`           |
+| `no-path-concat`        | `n/no-path-concat`           |
+| `no-process-env`        | `n/no-process-env`           |
+| `no-process-exit`       | `n/no-process-exit`          |
+| `no-restricted-modules` | `n/no-restricted-require`    |
+| `no-sync`               | `n/no-sync`                  |
+
+> **Note:** `no-restricted-modules` now maps to `n/no-restricted-require` to cover `require()` usage, matching the old CommonJS intent.
+
+### Rules removed from ESLint core (moved to `eslint-plugin-jsdoc`)
+
+The following jsdoc rules were removed from ESLint core and are now provided by `eslint-plugin-jsdoc`. The new config keeps them `off` to mirror previous behaviour.
+
+| Old rule (ESLint core) | New rule (`eslint-plugin-jsdoc`)                                                                |
+| ---------------------- | ----------------------------------------------------------------------------------------------- |
+| `require-jsdoc`        | `jsdoc/require-jsdoc`                                                                           |
+| `valid-jsdoc`          | `jsdoc/check-tag-names`, `jsdoc/require-param-description`, `jsdoc/require-returns-description` |
+
+### Other rules that have been superseded
+
+| Rule                     | Notes                                                                                          |
+| ------------------------ | ---------------------------------------------------------------------------------------------- |
+| `id-blacklist`           | Renamed to `id-denylist` in ESLint v7.4.0 (the old name was removed)                           |
+| `lines-around-directive` | Removed in ESLint v4.0.0 — superseded by `padding-line-between-statements`                     |
+| `newline-after-var`      | Removed in ESLint v4.0.0 — superseded by `padding-line-between-statements`                     |
+| `newline-before-return`  | Removed in ESLint v4.0.0 — superseded by `padding-line-between-statements`                     |
+| `no-catch-shadow`        | Deprecated in ESLint v5.1.0 — superseded by `no-shadow`                                        |
+| `no-native-reassign`     | Removed in ESLint v4.0.0 — superseded by `no-global-assign`                                    |
+| `no-negated-in-lhs`      | Removed in ESLint v3.3.0 — superseded by `no-unsafe-negation`                                  |
+| `no-spaced-func`         | Removed in ESLint v10 — superseded by `func-call-spacing` / `@stylistic/function-call-spacing` |
+| `require-jsdoc`          | Removed in ESLint v5.10.0 — superseded by `jsdoc/require-jsdoc` (kept `off`)                   |
+| `valid-jsdoc`            | Removed in ESLint v5.10.0 — superseded by `jsdoc/check-tag-names` (kept `off`)                 |
+
+## Rules that were on but have been deprecated
+
+`prefer-reflect` - Removed in ESLint v4.0.0 — the Reflect API guidance was rescinded
+
+### Rules that were `"off"` and remain `"off"` in the new config
+
+These rules were set to `"off"` in the old config and are carried over explicitly as `"off"` in the new flat config — behaviour is unchanged:
+
+`capitalized-comments`, `consistent-return`, `id-length`, `init-declarations`, `max-len`, `max-lines`, `max-statements`, `no-multi-assign`, `no-negated-condition`, `no-nested-ternary`, `no-shadow`, `no-ternary`, `no-underscore-dangle`, `no-warning-comments`, `object-shorthand`, `prefer-arrow-callback`, `prefer-rest-params`, `prefer-spread`, `prefer-template`, `sort-keys`, `sort-vars`, `wrap-regex`
+
+### Rules that were `"off"` and are omitted from the new config entirely
+
+These rules were `"off"` in the old config and have been deprecated in ESLint 8.53.0:
+
+`lines-around-comment`, `multiline-ternary`, `newline-per-chained-call`
+
+---
+
+### Other notable ESLint v10 breaking changes
+
+- **Old config format removed**: `.eslintrc` / `.eslintrc.json` / `.eslintrc.js` are no longer supported. Config must be in `eslint.config.js` (flat config format).
+- **`eslint:recommended` updated**: Three new rules are now enabled — `no-unassigned-vars`, `no-useless-assignment`, `preserve-caught-error`.
+- **`eslint-env` comments now error**: `/* eslint-env node */` style comments cause a lint error in v10. Remove them and configure globals in the config file instead.
+- **Node.js requirement**: ESLint v10 requires Node.js v20.19+, v22.13+, or v24+.
+- **`no-shadow-restricted-names`**: Now reports `globalThis` by default (`reportGlobalThis` defaults to `true`).
+- **`radix` rule options**: The `"always"` and `"as-needed"` string options are deprecated; the rule now always enforces providing a radix.
+
+---
+
+### Dependency changes
+
+| Package                    | Before    | After                                                          |
+| -------------------------- | --------- | -------------------------------------------------------------- |
+| `eslint` (peer)            | `>=8`     | `>=10`                                                         |
+| `eslint` (dev)             | `^8.57.1` | `^10.0.0`                                                      |
+| `@eslint/js`               | —         | `^10.0.0` (new, provides `eslint:recommended` for flat config) |
+| `@stylistic/eslint-plugin` | —         | `^4.4.1` (new, provides all moved stylistic rules)             |
+| `eslint-plugin-jsdoc`      | —         | `^62.7.0` (new, provides replacements for removed jsdoc rules) |

--- a/index.js
+++ b/index.js
@@ -1,12 +1,32 @@
 const os = require("os");
 const js = require("@eslint/js");
 const stylistic = require("@stylistic/eslint-plugin");
+const nodePlugin = require("eslint-plugin-n");
+const jsdoc = require("eslint-plugin-jsdoc");
 
 module.exports = [
   js.configs.recommended,
   {
     plugins: {
       "@stylistic": stylistic,
+      n: nodePlugin,
+      jsdoc,
+    },
+    languageOptions: {
+      globals: {
+        __dirname: "readonly",
+        __filename: "readonly",
+        exports: "readonly",
+        module: "readonly",
+        require: "readonly",
+        process: "readonly",
+        setTimeout: "readonly",
+        setInterval: "readonly",
+        setImmediate: "readonly",
+        clearTimeout: "readonly",
+        clearInterval: "readonly",
+        clearImmediate: "readonly",
+      },
     },
     rules: {
       // ── ESLint core rules ────────────────────────────────────────────
@@ -16,6 +36,7 @@ module.exports = [
       "arrow-body-style": ["error", "as-needed"],
       "block-scoped-var": "error",
       camelcase: "error",
+      "capitalized-comments": "off",
       "class-methods-use-this": "error",
       complexity: "error",
       "consistent-return": "off",
@@ -37,8 +58,6 @@ module.exports = [
       "max-len": "off",
       "max-lines": "off",
       "max-nested-callbacks": "error",
-      // This requires too much refactoring to do at the moment, so leaving
-      // as a warning until we come back and focus on eslint unification
       "max-params": ["warn", 5],
       "max-statements": "off",
       "new-cap": "error",
@@ -84,6 +103,7 @@ module.exports = [
       ],
       "no-multi-assign": "off",
       "no-multi-str": "error",
+      "no-global-assign": "error",
       "no-negated-condition": "off",
       "no-nested-ternary": "off",
       "no-new": "error",
@@ -110,6 +130,7 @@ module.exports = [
       "no-ternary": "off",
       "no-throw-literal": "error",
       "no-undef-init": "error",
+      "no-unsafe-negation": "error",
       "no-undefined": "error",
       "no-underscore-dangle": "off",
       "no-unmodified-loop-condition": "error",
@@ -155,6 +176,26 @@ module.exports = [
       "vars-on-top": "error",
       "wrap-regex": "off",
       yoda: ["error", "never"],
+
+      // ── eslint-plugin-n rules (moved from ESLint core) ───────────────
+
+      "n/callback-return": "off",
+      "n/global-require": "error",
+      "n/handle-callback-err": "error",
+      "n/no-mixed-requires": "off",
+      "n/no-new-require": "error",
+      "n/no-path-concat": "error",
+      "n/no-process-env": "error",
+      "n/no-process-exit": "error",
+      "n/no-restricted-require": "error",
+      "n/no-sync": "error",
+
+      // ── eslint-plugin-jsdoc rules (replacements for removed core rules) ─
+
+      "jsdoc/require-jsdoc": "off",
+      "jsdoc/check-tag-names": "off",
+      "jsdoc/require-param-description": "off",
+      "jsdoc/require-returns-description": "off",
 
       // ── @stylistic rules (moved from ESLint core in v8.53.0) ─────────
 

--- a/index.js
+++ b/index.js
@@ -1,324 +1,324 @@
-const os = require("os");
-const js = require("@eslint/js");
-const stylistic = require("@stylistic/eslint-plugin");
-const nodePlugin = require("eslint-plugin-n");
-const jsdoc = require("eslint-plugin-jsdoc");
+const os = require("os"),
+    js = require("@eslint/js"),
+    stylistic = require("@stylistic/eslint-plugin"),
+    nodePlugin = require("eslint-plugin-n"),
+    jsdoc = require("eslint-plugin-jsdoc");
 
 module.exports = [
-  js.configs.recommended,
-  {
-    plugins: {
-      "@stylistic": stylistic,
-      n: nodePlugin,
-      jsdoc,
-    },
-    languageOptions: {
-      globals: {
-        __dirname: "readonly",
-        __filename: "readonly",
-        exports: "readonly",
-        module: "readonly",
-        require: "readonly",
-        process: "readonly",
-        setTimeout: "readonly",
-        setInterval: "readonly",
-        setImmediate: "readonly",
-        clearTimeout: "readonly",
-        clearInterval: "readonly",
-        clearImmediate: "readonly",
-      },
-    },
-    rules: {
-      // ── ESLint core rules ────────────────────────────────────────────
+    js.configs.recommended,
+    {
+        plugins: {
+            "@stylistic": stylistic,
+            n: nodePlugin,
+            jsdoc
+        },
+        languageOptions: {
+            globals: {
+                __dirname: "readonly",
+                __filename: "readonly",
+                exports: "readonly",
+                module: "readonly",
+                require: "readonly",
+                process: "readonly",
+                setTimeout: "readonly",
+                setInterval: "readonly",
+                setImmediate: "readonly",
+                clearTimeout: "readonly",
+                clearInterval: "readonly",
+                clearImmediate: "readonly"
+            }
+        },
+        rules: {
+            // ── ESLint core rules ────────────────────────────────────────────
 
-      "accessor-pairs": "error",
-      "array-callback-return": "error",
-      "arrow-body-style": ["error", "as-needed"],
-      "block-scoped-var": "error",
-      camelcase: "error",
-      "capitalized-comments": "off",
-      "class-methods-use-this": "error",
-      complexity: "error",
-      "consistent-return": "off",
-      "consistent-this": ["error", "self"],
-      curly: "error",
-      "default-case": "error",
-      "dot-notation": "error",
-      eqeqeq: "error",
-      "func-name-matching": "error",
-      "func-names": ["error", "never"],
-      "func-style": "error",
-      "guard-for-in": "error",
-      "id-denylist": "error",
-      "id-length": "off",
-      "id-match": "error",
-      "init-declarations": "off",
-      "line-comment-position": "error",
-      "max-depth": "error",
-      "max-len": "off",
-      "max-lines": "off",
-      "max-nested-callbacks": "error",
-      "max-params": ["warn", 5],
-      "max-statements": "off",
-      "new-cap": "error",
-      "no-alert": "error",
-      "no-array-constructor": "error",
-      "no-await-in-loop": "error",
-      "no-bitwise": "error",
-      "no-caller": "error",
-      "no-constant-condition": "error",
-      "no-continue": "error",
-      "no-div-regex": "error",
-      "no-duplicate-imports": "error",
-      "no-else-return": "error",
-      "no-empty-function": "error",
-      "no-eq-null": "error",
-      "no-eval": "error",
-      "no-extend-native": "error",
-      "no-extra-bind": "error",
-      "no-extra-label": "error",
-      "no-implicit-globals": "error",
-      "no-implied-eval": "error",
-      "no-inline-comments": "error",
-      "no-invalid-this": "error",
-      "no-iterator": "error",
-      "no-label-var": "error",
-      "no-labels": "error",
-      "no-lone-blocks": "error",
-      "no-lonely-if": "error",
-      "no-loop-func": "error",
-      "no-magic-numbers": [
-        "error",
-        {
-          ignore: [
-            // These are numbers that it's reasonable we would want to ignore
-            -1, 0, 1,
-            // These are HTTP statuses. Ideally we would make these constants, but that's a
-            // job for a more thorough eslint unification task.
-            200,
-            204, 302, 400, 403, 404, 500,
-          ],
-          ignoreArrayIndexes: true,
-        },
-      ],
-      "no-multi-assign": "off",
-      "no-multi-str": "error",
-      "no-global-assign": "error",
-      "no-negated-condition": "off",
-      "no-nested-ternary": "off",
-      "no-new": "error",
-      "no-new-func": "error",
-      "no-new-object": "error",
-      "no-new-wrappers": "error",
-      "no-octal-escape": "error",
-      "no-param-reassign": "error",
-      "no-plusplus": "error",
-      "no-proto": "error",
-      "no-prototype-builtins": "off",
-      "no-restricted-globals": "error",
-      "no-restricted-imports": "error",
-      "no-restricted-properties": "error",
-      "no-restricted-syntax": "error",
-      "no-return-assign": "error",
-      "no-return-await": "error",
-      "no-script-url": "error",
-      "no-self-compare": "error",
-      "no-sequences": "error",
-      "no-shadow": "off",
-      "no-shadow-restricted-names": "error",
-      "no-template-curly-in-string": "error",
-      "no-ternary": "off",
-      "no-throw-literal": "error",
-      "no-undef-init": "error",
-      "no-unsafe-negation": "error",
-      "no-undefined": "error",
-      "no-underscore-dangle": "off",
-      "no-unmodified-loop-condition": "error",
-      "no-unneeded-ternary": "error",
-      "no-unused-expressions": "error",
-      "no-use-before-define": "error",
-      "no-useless-call": "error",
-      "no-useless-computed-key": "error",
-      "no-useless-concat": "error",
-      "no-useless-constructor": "error",
-      "no-useless-escape": "error",
-      "no-useless-rename": "error",
-      "no-useless-return": "error",
-      "no-var": "error",
-      "no-void": "error",
-      "no-warning-comments": "off",
-      "no-with": "error",
-      "object-shorthand": "off",
-      "one-var": [
-        "error",
-        {
-          var: "always",
-          let: "consecutive",
-          const: "consecutive",
-        },
-      ],
-      "operator-assignment": ["error", "always"],
-      "prefer-arrow-callback": "off",
-      "prefer-const": "error",
-      "prefer-numeric-literals": "error",
-      "prefer-promise-reject-errors": "error",
-      "prefer-rest-params": "off",
-      "prefer-spread": "off",
-      "prefer-template": "off",
-      radix: "error",
-      "require-await": "error",
-      "sort-imports": "error",
-      "sort-keys": "off",
-      "sort-vars": "off",
-      strict: "error",
-      "symbol-description": "error",
-      "unicode-bom": ["error", "never"],
-      "vars-on-top": "error",
-      "wrap-regex": "off",
-      yoda: ["error", "never"],
+            "accessor-pairs": "error",
+            "array-callback-return": "error",
+            "arrow-body-style": ["error", "as-needed"],
+            "block-scoped-var": "error",
+            camelcase: "error",
+            "capitalized-comments": "off",
+            "class-methods-use-this": "error",
+            complexity: "error",
+            "consistent-return": "off",
+            "consistent-this": ["error", "self"],
+            curly: "error",
+            "default-case": "error",
+            "dot-notation": "error",
+            eqeqeq: "error",
+            "func-name-matching": "error",
+            "func-names": ["error", "never"],
+            "func-style": "error",
+            "guard-for-in": "error",
+            "id-denylist": "error",
+            "id-length": "off",
+            "id-match": "error",
+            "init-declarations": "off",
+            "line-comment-position": "error",
+            "max-depth": "error",
+            "max-len": "off",
+            "max-lines": "off",
+            "max-nested-callbacks": "error",
+            "max-params": ["warn", 5],
+            "max-statements": "off",
+            "new-cap": "error",
+            "no-alert": "error",
+            "no-array-constructor": "error",
+            "no-await-in-loop": "error",
+            "no-bitwise": "error",
+            "no-caller": "error",
+            "no-constant-condition": "error",
+            "no-continue": "error",
+            "no-div-regex": "error",
+            "no-duplicate-imports": "error",
+            "no-else-return": "error",
+            "no-empty-function": "error",
+            "no-eq-null": "error",
+            "no-eval": "error",
+            "no-extend-native": "error",
+            "no-extra-bind": "error",
+            "no-extra-label": "error",
+            "no-implicit-globals": "error",
+            "no-implied-eval": "error",
+            "no-inline-comments": "error",
+            "no-invalid-this": "error",
+            "no-iterator": "error",
+            "no-label-var": "error",
+            "no-labels": "error",
+            "no-lone-blocks": "error",
+            "no-lonely-if": "error",
+            "no-loop-func": "error",
+            "no-magic-numbers": [
+                "error",
+                {
+                    ignore: [
+                        // These are numbers that it's reasonable we would want to ignore
+                        -1, 0, 1,
+                        // These are HTTP statuses. Ideally we would make these constants, but that's a
+                        // job for a more thorough eslint unification task.
+                        200,
+                        204, 302, 400, 403, 404, 500
+                    ],
+                    ignoreArrayIndexes: true
+                }
+            ],
+            "no-multi-assign": "off",
+            "no-multi-str": "error",
+            "no-global-assign": "error",
+            "no-negated-condition": "off",
+            "no-nested-ternary": "off",
+            "no-new": "error",
+            "no-new-func": "error",
+            "no-new-object": "error",
+            "no-new-wrappers": "error",
+            "no-octal-escape": "error",
+            "no-param-reassign": "error",
+            "no-plusplus": "error",
+            "no-proto": "error",
+            "no-prototype-builtins": "off",
+            "no-restricted-globals": "error",
+            "no-restricted-imports": "error",
+            "no-restricted-properties": "error",
+            "no-restricted-syntax": "error",
+            "no-return-assign": "error",
+            "no-return-await": "error",
+            "no-script-url": "error",
+            "no-self-compare": "error",
+            "no-sequences": "error",
+            "no-shadow": "off",
+            "no-shadow-restricted-names": "error",
+            "no-template-curly-in-string": "error",
+            "no-ternary": "off",
+            "no-throw-literal": "error",
+            "no-undef-init": "error",
+            "no-unsafe-negation": "error",
+            "no-undefined": "error",
+            "no-underscore-dangle": "off",
+            "no-unmodified-loop-condition": "error",
+            "no-unneeded-ternary": "error",
+            "no-unused-expressions": "error",
+            "no-use-before-define": "error",
+            "no-useless-call": "error",
+            "no-useless-computed-key": "error",
+            "no-useless-concat": "error",
+            "no-useless-constructor": "error",
+            "no-useless-escape": "error",
+            "no-useless-rename": "error",
+            "no-useless-return": "error",
+            "no-var": "error",
+            "no-void": "error",
+            "no-warning-comments": "off",
+            "no-with": "error",
+            "object-shorthand": "off",
+            "one-var": [
+                "error",
+                {
+                    var: "always",
+                    let: "consecutive",
+                    const: "consecutive"
+                }
+            ],
+            "operator-assignment": ["error", "always"],
+            "prefer-arrow-callback": "off",
+            "prefer-const": "error",
+            "prefer-numeric-literals": "error",
+            "prefer-promise-reject-errors": "error",
+            "prefer-rest-params": "off",
+            "prefer-spread": "off",
+            "prefer-template": "off",
+            radix: "error",
+            "require-await": "error",
+            "sort-imports": "error",
+            "sort-keys": "off",
+            "sort-vars": "off",
+            strict: "error",
+            "symbol-description": "error",
+            "unicode-bom": ["error", "never"],
+            "vars-on-top": "error",
+            "wrap-regex": "off",
+            yoda: ["error", "never"],
 
-      // ── eslint-plugin-n rules (moved from ESLint core) ───────────────
+            // ── eslint-plugin-n rules (moved from ESLint core) ───────────────
 
-      "n/callback-return": "off",
-      "n/global-require": "error",
-      "n/handle-callback-err": "error",
-      "n/no-mixed-requires": "off",
-      "n/no-new-require": "error",
-      "n/no-path-concat": "error",
-      "n/no-process-env": "error",
-      "n/no-process-exit": "error",
-      "n/no-restricted-require": "error",
-      "n/no-sync": "error",
+            "n/callback-return": "off",
+            "n/global-require": "error",
+            "n/handle-callback-err": "error",
+            "n/no-mixed-requires": "off",
+            "n/no-new-require": "error",
+            "n/no-path-concat": "error",
+            "n/no-process-env": "error",
+            "n/no-process-exit": "error",
+            "n/no-restricted-require": "error",
+            "n/no-sync": "error",
 
-      // ── eslint-plugin-jsdoc rules (replacements for removed core rules) ─
+            // ── eslint-plugin-jsdoc rules (replacements for removed core rules) ─
 
-      "jsdoc/require-jsdoc": "off",
-      "jsdoc/check-tag-names": "off",
-      "jsdoc/require-param-description": "off",
-      "jsdoc/require-returns-description": "off",
+            "jsdoc/require-jsdoc": "off",
+            "jsdoc/check-tag-names": "off",
+            "jsdoc/require-param-description": "off",
+            "jsdoc/require-returns-description": "off",
 
-      // ── @stylistic rules (moved from ESLint core in v8.53.0) ─────────
+            // ── @stylistic rules (moved from ESLint core in v8.53.0) ─────────
 
-      "@stylistic/array-bracket-spacing": "error",
-      "@stylistic/arrow-parens": "error",
-      "@stylistic/arrow-spacing": "error",
-      "@stylistic/block-spacing": "error",
-      "@stylistic/brace-style": ["error", "stroustrup"],
-      "@stylistic/comma-dangle": "error",
-      "@stylistic/comma-spacing": [
-        "error",
-        {
-          after: true,
-          before: false,
-        },
-      ],
-      "@stylistic/comma-style": ["error", "last"],
-      "@stylistic/computed-property-spacing": ["error", "never"],
-      "@stylistic/dot-location": ["error", "property"],
-      "@stylistic/eol-last": "error",
-      "@stylistic/function-call-spacing": "error",
-      "@stylistic/generator-star-spacing": "error",
-      "@stylistic/indent": [
-        "error",
-        4,
-        {
-          SwitchCase: 1,
-        },
-      ],
-      "@stylistic/jsx-quotes": "error",
-      "@stylistic/key-spacing": "error",
-      "@stylistic/keyword-spacing": "error",
-      "@stylistic/linebreak-style": [
-        // this is a warning because our build system checks out on Linux
-        // then copies to Windows causing the line endings to be mismatched
-        "warn",
-        os.EOL === "\r\n" ? "windows" : "unix",
-      ],
-      "@stylistic/max-statements-per-line": "error",
-      "@stylistic/new-parens": "error",
-      "@stylistic/no-confusing-arrow": [
-        "error",
-        {
-          allowParens: true,
-        },
-      ],
-      "@stylistic/no-extra-parens": [
-        "error",
-        "all",
-        { nestedBinaryExpressions: false },
-      ],
-      "@stylistic/no-floating-decimal": "error",
-      "@stylistic/no-mixed-operators": "error",
-      "@stylistic/no-multi-spaces": "error",
-      "@stylistic/no-multiple-empty-lines": [
-        "error",
-        {
-          max: 1,
-          maxBOF: 0,
-          maxEOF: 0,
-        },
-      ],
-      "@stylistic/no-tabs": "error",
-      "@stylistic/no-trailing-spaces": "error",
-      "@stylistic/no-whitespace-before-property": "error",
-      "@stylistic/object-curly-newline": [
-        "error",
-        {
-          multiline: true,
-          consistent: true,
-        },
-      ],
-      "@stylistic/object-curly-spacing": "error",
-      "@stylistic/object-property-newline": [
-        "error",
-        {
-          allowAllPropertiesOnSameLine: true,
-        },
-      ],
-      "@stylistic/one-var-declaration-per-line": "error",
-      "@stylistic/operator-linebreak": ["error", "before"],
-      "@stylistic/padded-blocks": ["error", "never"],
-      "@stylistic/padding-line-between-statements": [
-        "error",
-        { blankLine: "always", prev: "*", next: "return" },
-        { blankLine: "always", prev: ["const", "let", "var"], next: "*" },
-        {
-          blankLine: "any",
-          prev: ["const", "let", "var"],
-          next: ["const", "let", "var"],
-        },
-      ],
-      "@stylistic/quote-props": ["error", "as-needed"],
-      "@stylistic/quotes": ["error", "double"],
-      "@stylistic/rest-spread-spacing": "error",
-      "@stylistic/semi": "error",
-      "@stylistic/semi-spacing": [
-        "error",
-        {
-          after: true,
-          before: false,
-        },
-      ],
-      "@stylistic/space-before-blocks": "error",
-      "@stylistic/space-before-function-paren": "error",
-      "@stylistic/space-in-parens": ["error", "never"],
-      "@stylistic/space-infix-ops": "error",
-      "@stylistic/space-unary-ops": [
-        2,
-        {
-          words: true,
-          nonwords: false,
-          overrides: {
-            "!": true,
-            "!!": true,
-          },
-        },
-      ],
-      "@stylistic/spaced-comment": ["error", "always"],
-      "@stylistic/template-curly-spacing": "error",
-      "@stylistic/template-tag-spacing": "error",
-      "@stylistic/wrap-iife": "error",
-      "@stylistic/yield-star-spacing": "error",
-    },
-  },
+            "@stylistic/array-bracket-spacing": "error",
+            "@stylistic/arrow-parens": "error",
+            "@stylistic/arrow-spacing": "error",
+            "@stylistic/block-spacing": "error",
+            "@stylistic/brace-style": ["error", "stroustrup"],
+            "@stylistic/comma-dangle": "error",
+            "@stylistic/comma-spacing": [
+                "error",
+                {
+                    after: true,
+                    before: false
+                }
+            ],
+            "@stylistic/comma-style": ["error", "last"],
+            "@stylistic/computed-property-spacing": ["error", "never"],
+            "@stylistic/dot-location": ["error", "property"],
+            "@stylistic/eol-last": "error",
+            "@stylistic/function-call-spacing": "error",
+            "@stylistic/generator-star-spacing": "error",
+            "@stylistic/indent": [
+                "error",
+                4,
+                {
+                    SwitchCase: 1
+                }
+            ],
+            "@stylistic/jsx-quotes": "error",
+            "@stylistic/key-spacing": "error",
+            "@stylistic/keyword-spacing": "error",
+            "@stylistic/linebreak-style": [
+                // this is a warning because our build system checks out on Linux
+                // then copies to Windows causing the line endings to be mismatched
+                "warn",
+                os.EOL === "\r\n" ? "windows" : "unix"
+            ],
+            "@stylistic/max-statements-per-line": "error",
+            "@stylistic/new-parens": "error",
+            "@stylistic/no-confusing-arrow": [
+                "error",
+                {
+                    allowParens: true
+                }
+            ],
+            "@stylistic/no-extra-parens": [
+                "error",
+                "all",
+                {nestedBinaryExpressions: false}
+            ],
+            "@stylistic/no-floating-decimal": "error",
+            "@stylistic/no-mixed-operators": "error",
+            "@stylistic/no-multi-spaces": "error",
+            "@stylistic/no-multiple-empty-lines": [
+                "error",
+                {
+                    max: 1,
+                    maxBOF: 0,
+                    maxEOF: 0
+                }
+            ],
+            "@stylistic/no-tabs": "error",
+            "@stylistic/no-trailing-spaces": "error",
+            "@stylistic/no-whitespace-before-property": "error",
+            "@stylistic/object-curly-newline": [
+                "error",
+                {
+                    multiline: true,
+                    consistent: true
+                }
+            ],
+            "@stylistic/object-curly-spacing": "error",
+            "@stylistic/object-property-newline": [
+                "error",
+                {
+                    allowAllPropertiesOnSameLine: true
+                }
+            ],
+            "@stylistic/one-var-declaration-per-line": "error",
+            "@stylistic/operator-linebreak": ["error", "before"],
+            "@stylistic/padded-blocks": ["error", "never"],
+            "@stylistic/padding-line-between-statements": [
+                "error",
+                {blankLine: "always", prev: "*", next: "return"},
+                {blankLine: "always", prev: ["const", "let", "var"], next: "*"},
+                {
+                    blankLine: "any",
+                    prev: ["const", "let", "var"],
+                    next: ["const", "let", "var"]
+                }
+            ],
+            "@stylistic/quote-props": ["error", "as-needed"],
+            "@stylistic/quotes": ["error", "double"],
+            "@stylistic/rest-spread-spacing": "error",
+            "@stylistic/semi": "error",
+            "@stylistic/semi-spacing": [
+                "error",
+                {
+                    after: true,
+                    before: false
+                }
+            ],
+            "@stylistic/space-before-blocks": "error",
+            "@stylistic/space-before-function-paren": "error",
+            "@stylistic/space-in-parens": ["error", "never"],
+            "@stylistic/space-infix-ops": "error",
+            "@stylistic/space-unary-ops": [
+                2,
+                {
+                    words: true,
+                    nonwords: false,
+                    overrides: {
+                        "!": true,
+                        "!!": true
+                    }
+                }
+            ],
+            "@stylistic/spaced-comment": ["error", "always"],
+            "@stylistic/template-curly-spacing": "error",
+            "@stylistic/template-tag-spacing": "error",
+            "@stylistic/wrap-iife": "error",
+            "@stylistic/yield-star-spacing": "error"
+        }
+    }
 ];

--- a/index.js
+++ b/index.js
@@ -1,336 +1,283 @@
-module.exports = {
-    "extends": "eslint:recommended",
-    "rules": {
-        "accessor-pairs": "error",
-        "array-bracket-spacing": "error",
-        "array-callback-return": "error",
-        "arrow-body-style": ["error", "as-needed"],
-        "arrow-parens": "error",
-        "arrow-spacing": "error",
-        "block-scoped-var": "error",
-        "block-spacing": "error",
-        "brace-style": [
-            "error",
-            "stroustrup"
-        ],
-        "callback-return": "off",
-        "camelcase": "error",
-        "capitalized-comments": "off",
-        "class-methods-use-this": "error",
-        "comma-dangle": "error",
-        "comma-spacing": [
-            "error",
-            {
-                "after": true,
-                "before": false
-            }
-        ],
-        "comma-style": [
-            "error",
-            "last"
-        ],
-        "complexity": "error",
-        "computed-property-spacing": [
-            "error",
-            "never"
-        ],
-        "consistent-return": "off",
-        "consistent-this": [
-            "error",
-            "self"
-        ],
-        "curly": "error",
-        "default-case": "error",
-        "dot-location": [
-            "error",
-            "property"
-        ],
-        "dot-notation": "error",
-        "eol-last": "error",
-        "eqeqeq": "error",
-        "func-call-spacing": "error",
-        "func-name-matching": "error",
-        "func-names": [
-            "error",
-            "never"
-        ],
-        "func-style": "error",
-        "generator-star-spacing": "error",
-        "global-require": "error",
-        "guard-for-in": "error",
-        "handle-callback-err": "error",
-        "id-blacklist": "error",
-        "id-length": "off",
-        "id-match": "error",
-        "indent": [
-            "error",
-            4,
-            {
-                "SwitchCase": 1
-            }
-         ],
-        "init-declarations": "off",
-        "jsx-quotes": "error",
-        "key-spacing": "error",
-        "keyword-spacing": "error",
-        "line-comment-position": "error",
-        "linebreak-style": [
-            // this is a warning because our build system checks out on Linux
-            // then copies to Windows causing the line endings to be mismatched
-            "warn",
-            (require("os").EOL === "\r\n" ? "windows" : "unix")
-        ],
-        "lines-around-comment": "off",
-        "lines-around-directive": "off",
-        "max-depth": "error",
-        "max-len": "off",
-        "max-lines": "off",
-        "max-nested-callbacks": "error",
-        // This requires too much refactoring to do at the moment, so leaving
-        // as a warning until we come back and focus on eslint unification
-        "max-params": ["warn", 5],
-        "max-statements": "off",
-        "max-statements-per-line": "error",
-        "multiline-ternary": "off",
-        "new-cap": "error",
-        "new-parens": "error",
-        "newline-after-var": [
-            "error",
-            "always"
-        ],
-        "newline-before-return": "off",
-        "newline-per-chained-call": "off",
-        "no-alert": "error",
-        "no-array-constructor": "error",
-        "no-await-in-loop": "error",
-        "no-bitwise": "error",
-        "no-caller": "error",
-        "no-catch-shadow": "error",
-        "no-confusing-arrow": [
-            "error",
-            {
-                "allowParens": true
-            }
-        ],
-        "no-constant-condition": "error",
-        "no-continue": "error",
-        "no-div-regex": "error",
-        "no-duplicate-imports": "error",
-        "no-else-return": "error",
-        "no-empty-function": "error",
-        "no-eq-null": "error",
-        "no-eval": "error",
-        "no-extend-native": "error",
-        "no-extra-bind": "error",
-        "no-extra-label": "error",
-        "no-extra-parens": [
-            "error",
-            "all",
-            {"nestedBinaryExpressions": false}
-        ],
-        "no-floating-decimal": "error",
-        "no-implicit-globals": "error",
-        "no-implied-eval": "error",
-        "no-inline-comments": "error",
-        "no-invalid-this": "error",
-        "no-iterator": "error",
-        "no-label-var": "error",
-        "no-labels": "error",
-        "no-lone-blocks": "error",
-        "no-lonely-if": "error",
-        "no-loop-func": "error",
-        "no-magic-numbers": [
-            "error",
-            {
-                "ignore": [
-                    // These are numbers that it's reasonable we would want to ignore
-                    -1, 0, 1,
-                    // These are HTTP statuses. Ideally we would make these constants, but that's a
-                    // job for a more thorough eslint unification task.
-                    200, 204, 302, 400, 403, 404, 500
-                ],
-                "ignoreArrayIndexes": true
-            }
-        ],
-        "no-mixed-operators": "error",
-        "no-mixed-requires": "off",
-        "no-multi-assign": "off",
-        "no-multi-spaces": "error",
-        "no-multi-str": "error",
-        "no-multiple-empty-lines": [
-            "error",
-            {
-                "max": 1,
-                "maxBOF": 0,
-                "maxEOF": 0
-            }
-        ],
-        "no-native-reassign": "error",
-        "no-negated-condition": "off",
-        "no-negated-in-lhs": "error",
-        "no-nested-ternary": "off",
-        "no-new": "error",
-        "no-new-func": "error",
-        "no-new-object": "error",
-        "no-new-require": "error",
-        "no-new-wrappers": "error",
-        "no-octal-escape": "error",
-        "no-param-reassign": "error",
-        "no-path-concat": "error",
-        "no-plusplus": "error",
-        "no-process-env": "error",
-        "no-process-exit": "error",
-        "no-proto": "error",
-        "no-prototype-builtins": "off",
-        "no-restricted-globals": "error",
-        "no-restricted-imports": "error",
-        "no-restricted-modules": "error",
-        "no-restricted-properties": "error",
-        "no-restricted-syntax": "error",
-        "no-return-assign": "error",
-        "no-return-await": "error",
-        "no-script-url": "error",
-        "no-self-compare": "error",
-        "no-sequences": "error",
-        "no-shadow": "off",
-        "no-shadow-restricted-names": "error",
-        "no-spaced-func": "error",
-        "no-sync": "error",
-        "no-tabs": "error",
-        "no-template-curly-in-string": "error",
-        "no-ternary": "off",
-        "no-throw-literal": "error",
-        "no-trailing-spaces": "error",
-        "no-undef-init": "error",
-        "no-undefined": "error",
-        "no-underscore-dangle": "off",
-        "no-unmodified-loop-condition": "error",
-        "no-unneeded-ternary": "error",
-        "no-unused-expressions": "error",
-        "no-use-before-define": "error",
-        "no-useless-call": "error",
-        "no-useless-computed-key": "error",
-        "no-useless-concat": "error",
-        "no-useless-constructor": "error",
-        "no-useless-escape": "error",
-        "no-useless-rename": "error",
-        "no-useless-return": "error",
-        "no-var": "error",
-        "no-void": "error",
-        "no-warning-comments": "off",
-        "no-whitespace-before-property": "error",
-        "no-with": "error",
-        "object-curly-newline": [
-            "error",
-            {
-                "multiline": true,
-                "consistent": true
-            }
-        ],
-        "object-curly-spacing": "error",
-        "object-property-newline": [
-            "error",
-            {
-                "allowAllPropertiesOnSameLine": true
-            }
-        ],
-        "object-shorthand": "off",
-        "one-var": [
-            "error",
-            {
-                "var": "always",
-                "let": "consecutive",
-                "const": "consecutive"
-            }
-        ],
-        "one-var-declaration-per-line": "error",
-        "operator-assignment": [
-            "error",
-            "always"
-        ],
-        "operator-linebreak": [
-            "error",
-            "before"
-        ],
-        "padded-blocks": [
-            "error",
-            "never"
-        ],
-        "padding-line-between-statements": [
-            "error",
-            {"blankLine": "always", "prev": "*", "next": "return"},
-            {"blankLine": "always", "prev": ["const", "let", "var"], "next": "*"},
-            {"blankLine": "any", "prev": ["const", "let", "var"], "next": ["const", "let", "var"]}
-        ],
-        "prefer-arrow-callback": "off",
-        "prefer-const": "error",
-        "prefer-numeric-literals": "error",
-        "prefer-promise-reject-errors": "error",
-        "prefer-reflect": "off",
-        "prefer-rest-params": "off",
-        "prefer-spread": "off",
-        "prefer-template": "off",
-        "quote-props": [
-            "error",
-            "as-needed"
-        ],
-        "quotes": [
-            "error",
-            "double"
-        ],
-        "radix": "error",
-        "require-await": "error",
-        "require-jsdoc": "off",
-        "rest-spread-spacing": "error",
-        "semi": "error",
-        "semi-spacing": [
-            "error",
-            {
-                "after": true,
-                "before": false
-            }
-        ],
-        "sort-imports": "error",
-        "sort-keys": "off",
-        "sort-vars": "off",
-        "space-before-blocks": "error",
-        "space-before-function-paren": "error",
-        "space-in-parens": [
-            "error",
-            "never"
-        ],
-        "space-infix-ops": "error",
-        "space-unary-ops": [
-            2,
-            {
-                "words": true,
-                "nonwords": false,
-                "overrides": {
-                    "!": true,
-                    "!!": true
-                }
-            }
-        ],
-        "spaced-comment": [
-            "error",
-            "always"
-        ],
-        "strict": "error",
-        "symbol-description": "error",
-        "template-curly-spacing": "error",
-        "template-tag-spacing": "error",
-        "unicode-bom": [
-            "error",
-            "never"
-        ],
-        "valid-jsdoc": "off",
-        "vars-on-top": "error",
-        "wrap-iife": "error",
-        "wrap-regex": "off",
-        "yield-star-spacing": "error",
-        "yoda": [
-            "error",
-            "never"
-        ]
-    }
-};
+const os = require("os");
+const js = require("@eslint/js");
+const stylistic = require("@stylistic/eslint-plugin");
+
+module.exports = [
+  js.configs.recommended,
+  {
+    plugins: {
+      "@stylistic": stylistic,
+    },
+    rules: {
+      // ── ESLint core rules ────────────────────────────────────────────
+
+      "accessor-pairs": "error",
+      "array-callback-return": "error",
+      "arrow-body-style": ["error", "as-needed"],
+      "block-scoped-var": "error",
+      camelcase: "error",
+      "class-methods-use-this": "error",
+      complexity: "error",
+      "consistent-return": "off",
+      "consistent-this": ["error", "self"],
+      curly: "error",
+      "default-case": "error",
+      "dot-notation": "error",
+      eqeqeq: "error",
+      "func-name-matching": "error",
+      "func-names": ["error", "never"],
+      "func-style": "error",
+      "guard-for-in": "error",
+      "id-denylist": "error",
+      "id-length": "off",
+      "id-match": "error",
+      "init-declarations": "off",
+      "line-comment-position": "error",
+      "max-depth": "error",
+      "max-len": "off",
+      "max-lines": "off",
+      "max-nested-callbacks": "error",
+      // This requires too much refactoring to do at the moment, so leaving
+      // as a warning until we come back and focus on eslint unification
+      "max-params": ["warn", 5],
+      "max-statements": "off",
+      "new-cap": "error",
+      "no-alert": "error",
+      "no-array-constructor": "error",
+      "no-await-in-loop": "error",
+      "no-bitwise": "error",
+      "no-caller": "error",
+      "no-constant-condition": "error",
+      "no-continue": "error",
+      "no-div-regex": "error",
+      "no-duplicate-imports": "error",
+      "no-else-return": "error",
+      "no-empty-function": "error",
+      "no-eq-null": "error",
+      "no-eval": "error",
+      "no-extend-native": "error",
+      "no-extra-bind": "error",
+      "no-extra-label": "error",
+      "no-implicit-globals": "error",
+      "no-implied-eval": "error",
+      "no-inline-comments": "error",
+      "no-invalid-this": "error",
+      "no-iterator": "error",
+      "no-label-var": "error",
+      "no-labels": "error",
+      "no-lone-blocks": "error",
+      "no-lonely-if": "error",
+      "no-loop-func": "error",
+      "no-magic-numbers": [
+        "error",
+        {
+          ignore: [
+            // These are numbers that it's reasonable we would want to ignore
+            -1, 0, 1,
+            // These are HTTP statuses. Ideally we would make these constants, but that's a
+            // job for a more thorough eslint unification task.
+            200,
+            204, 302, 400, 403, 404, 500,
+          ],
+          ignoreArrayIndexes: true,
+        },
+      ],
+      "no-multi-assign": "off",
+      "no-multi-str": "error",
+      "no-negated-condition": "off",
+      "no-nested-ternary": "off",
+      "no-new": "error",
+      "no-new-func": "error",
+      "no-new-object": "error",
+      "no-new-wrappers": "error",
+      "no-octal-escape": "error",
+      "no-param-reassign": "error",
+      "no-plusplus": "error",
+      "no-proto": "error",
+      "no-prototype-builtins": "off",
+      "no-restricted-globals": "error",
+      "no-restricted-imports": "error",
+      "no-restricted-properties": "error",
+      "no-restricted-syntax": "error",
+      "no-return-assign": "error",
+      "no-return-await": "error",
+      "no-script-url": "error",
+      "no-self-compare": "error",
+      "no-sequences": "error",
+      "no-shadow": "off",
+      "no-shadow-restricted-names": "error",
+      "no-template-curly-in-string": "error",
+      "no-ternary": "off",
+      "no-throw-literal": "error",
+      "no-undef-init": "error",
+      "no-undefined": "error",
+      "no-underscore-dangle": "off",
+      "no-unmodified-loop-condition": "error",
+      "no-unneeded-ternary": "error",
+      "no-unused-expressions": "error",
+      "no-use-before-define": "error",
+      "no-useless-call": "error",
+      "no-useless-computed-key": "error",
+      "no-useless-concat": "error",
+      "no-useless-constructor": "error",
+      "no-useless-escape": "error",
+      "no-useless-rename": "error",
+      "no-useless-return": "error",
+      "no-var": "error",
+      "no-void": "error",
+      "no-warning-comments": "off",
+      "no-with": "error",
+      "object-shorthand": "off",
+      "one-var": [
+        "error",
+        {
+          var: "always",
+          let: "consecutive",
+          const: "consecutive",
+        },
+      ],
+      "operator-assignment": ["error", "always"],
+      "prefer-arrow-callback": "off",
+      "prefer-const": "error",
+      "prefer-numeric-literals": "error",
+      "prefer-promise-reject-errors": "error",
+      "prefer-rest-params": "off",
+      "prefer-spread": "off",
+      "prefer-template": "off",
+      radix: "error",
+      "require-await": "error",
+      "sort-imports": "error",
+      "sort-keys": "off",
+      "sort-vars": "off",
+      strict: "error",
+      "symbol-description": "error",
+      "unicode-bom": ["error", "never"],
+      "vars-on-top": "error",
+      "wrap-regex": "off",
+      yoda: ["error", "never"],
+
+      // ── @stylistic rules (moved from ESLint core in v8.53.0) ─────────
+
+      "@stylistic/array-bracket-spacing": "error",
+      "@stylistic/arrow-parens": "error",
+      "@stylistic/arrow-spacing": "error",
+      "@stylistic/block-spacing": "error",
+      "@stylistic/brace-style": ["error", "stroustrup"],
+      "@stylistic/comma-dangle": "error",
+      "@stylistic/comma-spacing": [
+        "error",
+        {
+          after: true,
+          before: false,
+        },
+      ],
+      "@stylistic/comma-style": ["error", "last"],
+      "@stylistic/computed-property-spacing": ["error", "never"],
+      "@stylistic/dot-location": ["error", "property"],
+      "@stylistic/eol-last": "error",
+      "@stylistic/function-call-spacing": "error",
+      "@stylistic/generator-star-spacing": "error",
+      "@stylistic/indent": [
+        "error",
+        4,
+        {
+          SwitchCase: 1,
+        },
+      ],
+      "@stylistic/jsx-quotes": "error",
+      "@stylistic/key-spacing": "error",
+      "@stylistic/keyword-spacing": "error",
+      "@stylistic/linebreak-style": [
+        // this is a warning because our build system checks out on Linux
+        // then copies to Windows causing the line endings to be mismatched
+        "warn",
+        os.EOL === "\r\n" ? "windows" : "unix",
+      ],
+      "@stylistic/max-statements-per-line": "error",
+      "@stylistic/new-parens": "error",
+      "@stylistic/no-confusing-arrow": [
+        "error",
+        {
+          allowParens: true,
+        },
+      ],
+      "@stylistic/no-extra-parens": [
+        "error",
+        "all",
+        { nestedBinaryExpressions: false },
+      ],
+      "@stylistic/no-floating-decimal": "error",
+      "@stylistic/no-mixed-operators": "error",
+      "@stylistic/no-multi-spaces": "error",
+      "@stylistic/no-multiple-empty-lines": [
+        "error",
+        {
+          max: 1,
+          maxBOF: 0,
+          maxEOF: 0,
+        },
+      ],
+      "@stylistic/no-tabs": "error",
+      "@stylistic/no-trailing-spaces": "error",
+      "@stylistic/no-whitespace-before-property": "error",
+      "@stylistic/object-curly-newline": [
+        "error",
+        {
+          multiline: true,
+          consistent: true,
+        },
+      ],
+      "@stylistic/object-curly-spacing": "error",
+      "@stylistic/object-property-newline": [
+        "error",
+        {
+          allowAllPropertiesOnSameLine: true,
+        },
+      ],
+      "@stylistic/one-var-declaration-per-line": "error",
+      "@stylistic/operator-linebreak": ["error", "before"],
+      "@stylistic/padded-blocks": ["error", "never"],
+      "@stylistic/padding-line-between-statements": [
+        "error",
+        { blankLine: "always", prev: "*", next: "return" },
+        { blankLine: "always", prev: ["const", "let", "var"], next: "*" },
+        {
+          blankLine: "any",
+          prev: ["const", "let", "var"],
+          next: ["const", "let", "var"],
+        },
+      ],
+      "@stylistic/quote-props": ["error", "as-needed"],
+      "@stylistic/quotes": ["error", "double"],
+      "@stylistic/rest-spread-spacing": "error",
+      "@stylistic/semi": "error",
+      "@stylistic/semi-spacing": [
+        "error",
+        {
+          after: true,
+          before: false,
+        },
+      ],
+      "@stylistic/space-before-blocks": "error",
+      "@stylistic/space-before-function-paren": "error",
+      "@stylistic/space-in-parens": ["error", "never"],
+      "@stylistic/space-infix-ops": "error",
+      "@stylistic/space-unary-ops": [
+        2,
+        {
+          words: true,
+          nonwords: false,
+          overrides: {
+            "!": true,
+            "!!": true,
+          },
+        },
+      ],
+      "@stylistic/spaced-comment": ["error", "always"],
+      "@stylistic/template-curly-spacing": "error",
+      "@stylistic/template-tag-spacing": "error",
+      "@stylistic/wrap-iife": "error",
+      "@stylistic/yield-star-spacing": "error",
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@rusticisoftware/eslint-config",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 3
 }

--- a/package.json
+++ b/package.json
@@ -19,11 +19,15 @@
   "peerDependencies": {
     "@eslint/js": ">=10",
     "@stylistic/eslint-plugin": ">=4",
+    "eslint-plugin-jsdoc": ">=62",
+    "eslint-plugin-n": ">=17",
     "eslint": ">=10"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",
     "@stylistic/eslint-plugin": "^4.4.1",
+    "eslint-plugin-jsdoc": "^62.7.0",
+    "eslint-plugin-n": "^17.0.0",
     "eslint": "^10.0.0",
     "mocha": "^10.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rusticisoftware/eslint-config",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "eslint configuration used by Rustici Software (mostly)",
   "main": "index.js",
   "scripts": {
@@ -17,10 +17,14 @@
   "author": "Support <support@rusticisoftware.com>",
   "license": "ISC",
   "peerDependencies": {
-    "eslint": ">=8"
+    "@eslint/js": ">=10",
+    "@stylistic/eslint-plugin": ">=4",
+    "eslint": ">=10"
   },
   "devDependencies": {
-    "eslint": "^8.57.1",
+    "@eslint/js": "^10.0.0",
+    "@stylistic/eslint-plugin": "^4.4.1",
+    "eslint": "^10.0.0",
     "mocha": "^10.0.0"
   }
 }


### PR DESCRIPTION
Updates eslint to v10
Updates config format to modern flat-file format
Imports ESLint Stylistic to maintain style rules that have been deprecated by eslint.